### PR TITLE
added an extra line to the serializer to return company_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ Status: 200
                 "job_description": "Looking for Turing grad/jr dev to be CTO",
                 "application_url": "www.example.com",
                 "contact_information": "boss@example.com",
-                "company_id": 1
+                "company_id": 1,
+                "company_name": "Google"
             }
         },
         {
@@ -258,7 +259,8 @@ Status: 200
                 "job_description": "Developing RESTful APIs and optimizing server performance.",
                 "application_url": "https://creativesolutions.com/careers/backend-developer",
                 "contact_information": "techlead@creativesolutions.com",
-                "company_id": 3
+                "company_id": 3,
+                "company_name": "Amazon"
             }
         }
     ]
@@ -348,7 +350,8 @@ Status: 200 OK
       :job_description=>"Looking for Turing grad/jr dev to be CTO",
       :application_url=>"www.example.com",
       :contact_information=>"boss@example.com",
-      :company_id=>35}}
+      :company_id=>35,
+      :company_name=>"Google"}}
 }
 ```
 

--- a/app/serializers/job_application_serializer.rb
+++ b/app/serializers/job_application_serializer.rb
@@ -7,5 +7,10 @@ class JobApplicationSerializer
              :job_description, 
              :application_url, 
              :contact_information, 
-             :company_id
+             :company_id,
+             :company_name
+             
+  attribute :company_name do |job_application|
+    job_application.company&.name
+  end
 end

--- a/spec/requests/api/v1/job_applications/job_application_create_spec.rb
+++ b/spec/requests/api/v1/job_applications/job_application_create_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "Job Application #create & #index", type: :request do
       expect(jobApp[:data][:attributes][:application_url]).to eq(job_application_params[:application_url])
       expect(jobApp[:data][:attributes][:contact_information]).to eq(job_application_params[:contact_information])
       expect(jobApp[:data][:attributes][:company_id]).to eq(job_application_params[:company_id])
+      expect(jobApp[:data][:attributes][:company_name]).to eq(@google.name)
     end
   end
 
@@ -146,6 +147,8 @@ RSpec.describe "Job Application #create & #index", type: :request do
       expect(first_application[:job_description]).to eq(@job_application1.job_description)
       expect(first_application[:application_url]).to eq(@job_application1.application_url)
       expect(first_application[:contact_information]).to eq(@job_application1.contact_information)
+      expect(first_application[:company_name]).to eq(@google.name)
+      expect(first_application[:company_id]).to eq(@google.id)
     end
   end
 


### PR DESCRIPTION
## Type of Change
- [x] refactor 🧑‍💻

<!--- Delete any above that do not apply to this PR -->

## Description
Added company_name to the fetch serializer and updated test and documentation to reflect the change. This was done in order to retrieve company names in the Fe

## Motivation and Context
Currently, you can't get company names in the FE with the current data coming back from the serializer

## Related Tickets
Merge pull request  that this expands upon is [Merge request)](https://github.com/turingschool/tracker-crm/commit/2ec388acab50e61bb3be816d33512fc2d2c3ce2d)

## Screenshots (if appropriate):

## Added Test?
- [x] Yes 🫡
- [x] All previous tests still pass 🥳



## Checklist:
- [x] My code follows the code style of this project.

- [x] I have updated the documentation accordingly.
