### PR TITLE
BE ContactsController #show

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "git.ignoreLimitWarning": true
+}

--- a/README.md
+++ b/README.md
@@ -697,6 +697,43 @@ raw json body with all fields:
         ]
         },
    ```
+#### Show a Contact that belongs to a User (not company contact)
+***Ensure you Create the Contact first for the user NOT company - 2 different Routes!***
+
+Request:
+```
+GET http://localhost:3001/api/v1/users/:user_id/contacts/:contact_id
+Authorization: Bearer Token - put in token for user
+```
+Successful Response:
+
+```
+{
+    "data": {
+        "id": "1",
+        "type": "contacts",
+        "attributes": {
+            "first_name": "Josnny",
+            "last_name": "Smsith",
+            "company_id": 1,
+            "email": "jonny@gmail.com",
+            "phone_number": "555-785-5555",
+            "notes": "Good contact for XYZ",
+            "user_id": 1,
+            "company": {
+                "id": 1,
+                "name": "Tech Innovators",
+                "website": "https://techinnovators.com",
+                "street_address": "123 Innovation Way",
+                "city": "San Francisco",
+                "state": "CA",
+                "zip_code": "94107",
+                "notes": "Reached out on LinkedIn, awaiting response."
+            }
+        }
+    }
+}
+```
 
 #### Contact Errors
 401 Error Response if no token provided:

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -61,11 +61,11 @@ module Api
         if contact.nil? || contact.user_id != user.id
           render json: ErrorSerializer.format_error(ErrorMessage.new("Contact not found", 404)), status: :not_found
         else
-          contact_data = ContactsSerializer.new(contact).serializable_hash
-
+          contact_data = ContactsSerializer.new(contact)
           render json: contact_data, status: :ok
         end
       end
+      
       private
 
       def contact_params

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -47,7 +47,6 @@ module Api
       end
 
       def show
-
         if params[:id].blank?
           render json: ErrorSerializer.format_error(ErrorMessage.new("Contact ID is missing", 400)), status: :bad_request
           return
@@ -65,7 +64,7 @@ module Api
           render json: contact_data, status: :ok
         end
       end
-      
+
       private
 
       def contact_params

--- a/app/controllers/api/v1/contacts_controller.rb
+++ b/app/controllers/api/v1/contacts_controller.rb
@@ -46,6 +46,26 @@ module Api
         end
       end
 
+      def show
+
+        if params[:id].blank?
+          render json: ErrorSerializer.format_error(ErrorMessage.new("Contact ID is missing", 400)), status: :bad_request
+          return
+        end
+
+        user = User.find(params[:user_id])
+        authorize user
+    
+        contact = Contact.find_by(id: params[:id])
+
+        if contact.nil? || contact.user_id != user.id
+          render json: ErrorSerializer.format_error(ErrorMessage.new("Contact not found", 404)), status: :not_found
+        else
+          contact_data = ContactsSerializer.new(contact).serializable_hash
+
+          render json: contact_data, status: :ok
+        end
+      end
       private
 
       def contact_params

--- a/app/policies/contact_policy.rb
+++ b/app/policies/contact_policy.rb
@@ -7,7 +7,7 @@ class ContactPolicy < ApplicationPolicy
   def create?
     admin? || user.present?
   end
-  
+
   class Scope < ApplicationPolicy::Scope
 
     def resolve

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         resources :companies, only: [:create, :index] do
           resources :contacts, only: [:create, :index]
         end
-        resources :contacts, only: [:index, :create]
+        resources :contacts, only: [:index, :create, :show]
         resource :dashboard, only: :show
       end
 

--- a/spec/requests/api/v1/contacts/show_spec.rb
+++ b/spec/requests/api/v1/contacts/show_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+describe "Contacts Controller", type: :request do
+  describe "#show action" do
+    context "Happy Paths" do
+      before(:each) do
+        @user = User.create!(name: "Me", email: "its_me", password: "reallyGoodPass")
+        @company = Company.create!(
+          name: "Turing", website: "www.turing.com", street_address: "123 Main St", 
+          city: "Denver", state: "CO", zip_code: "80218", user_id: @user.id
+        )
+        @contact = Contact.create!(first_name: "John", last_name: "Smith", 
+        company_id: @company.id, email: "123@example.com", phone_number: "123-555-6789", 
+        notes: "Notes here...", user_id: @user.id
+        )
+        user_params = { email: "its_me", password: "reallyGoodPass" }
+        post api_v1_sessions_path, params: user_params, as: :json
+        @token = JSON.parse(response.body)["token"]
+        
+        @user2 = User.create!(name: "Jane", email: "email", password: "Password")
+        user_params2 = { email: "email", password: "Password" }
+        post api_v1_sessions_path, params: user_params2, as: :json
+        @token2 = JSON.parse(response.body)["token"]
+      end
+
+      it "returns 200 and provides the appropriate contact details" do
+        get api_v1_user_contacts_path(@user.id, @contact.id), headers: { "Authorization" => "Bearer #{@token}" }, as: :json
+
+        expect(response).to be_successful
+
+        json = JSON.parse(response.body, symbolize_names: true)[:data].first
+
+        expect(json[:attributes][:first_name]).to eq("John")
+        expect(json[:attributes][:last_name]).to eq("Smith")
+        expect(json[:attributes][:email]).to eq("123@example.com")
+        expect(json[:attributes][:phone_number]).to eq("123-555-6789")
+        expect(json[:attributes][:notes]).to eq("Notes here...")
+        expect(json[:attributes][:company_id]).to eq(@company.id)
+      end
+
+      context "Sad Paths" do 
+        it "returns a 403 and an error message if no token is provided" do
+          get api_v1_user_contacts_path(@user.id, @contact.id), as: :json
+    
+          expect(response).to have_http_status(:unauthorized)
+          json = JSON.parse(response.body, symbolize_names: true)
+    
+          expect(json[:error]).to eq("Not authenticated")
+        end
+          
+        it "returns a 403 and an error message if an invalid token is provided" do
+          get api_v1_user_contacts_path(@user.id, @contact.id), headers: { "Authorization" => "Bearer invalid.token.here" }, as: :json
+    
+          expect(response).to have_http_status(:unauthorized)
+          json = JSON.parse(response.body, symbolize_names: true)
+    
+          expect(json[:error]).to eq("Not authenticated")
+        end
+
+        it "returns a 403 and an error message if the token is expired" do
+          expired_token = JWT.encode({ user_id: @user.id, exp: 1.hour.ago.to_i }, Rails.application.secret_key_base, "HS256")
+    
+          get api_v1_user_contacts_path(@user.id, @contact.id), headers: { "Authorization" => "Bearer #{expired_token}" }, as: :json
+    
+          expect(response).to have_http_status(:unauthorized)
+          json = JSON.parse(response.body, symbolize_names: true)
+    
+          expect(json[:error]).to eq("Not authenticated")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Type of Change
- [x] feature ⛲
- [x] documentation update 📃
- [x] refactor 🧑‍💻
- [x] testing 🧪
<!--- Delete any above that do not apply to this PR -->

## Description
By adding, in **routes.rb**, `:show` to the `:users`(not `:companies`) nested `:contacts` resource and adding corresponding #show action to **ContactsController**, the FE can now access and render a users individual contacts.  This is fully tested in Postman and green in RSpec.

## Motivation and Context
Issue #17 was affected by a prior refactor of the BE **ContactsController** that removed the #show action because of how the routes are now being nested.  While building my **ShowContact** component on the FE, I was getting a mystery 500 error which led me to see that BE's main had been refactored. 

## Related Tickets
closes #66 

## Screenshots (if appropriate):

## Added Test?
- [x] Yes 🫡
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
