### PR TITLE
Add a checklist item to notify deploys team when a PR includes a migration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,3 +33,4 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
+- [ ] This PR includes a Migration and I have notified the deployment team and PM so they can run the migration after the PR is merged.


### PR DESCRIPTION
## Type of Change
- [x] documentation update 📃


## Description
Adds a checklist item to notify deploys team when a PR includes a migration

## Motivation and Context
We have encountered bugs on the production site when a migration is merged but not also run on the production database. This can lead to the prod app crashing and being unsuable.

## Related Tickets
NA for this fix
Triggered by #105 

## Screenshots (if appropriate):

## Added Test?
- [x] No 🙅
