### PR TITLE
Feat/company delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,69 @@ Body:{
 }
 ```
 
+#### Delete a Company
+
+Request:
+
+DELETE /api/v1/users/:userid/companies/:id
+Headers:
+```
+json
+{
+  "Authorization": "Bearer <your_token_here>",
+  "Content-Type": "application/json"
+}
+```
+```
+Status: 200 OK
+{
+  "message": "Company successfully deleted"
+}
+```
+
+Error Responses:
+
+Company Not Found
+
+DELETE /api/v1/users/:userid/companies/9999
+Response:
+```
+Status: 404 Not Found
+{
+  "error": "Company not found"
+}
+```
+
+Unauthorized: No Token Provided
+
+DELETE /api/v1/users/:userid/companies/:id
+Response:
+```
+Status: 401 Unauthorized
+{
+  "error": "Not authenticated"
+}
+```
+
+Unauthorized: Invalid Token
+
+DELETE /api/v1/users/:userid/companies/:id
+Headers:
+```
+{
+  "Authorization": "Bearer invalid.token.here",
+  "Content-Type": "application/json"
+}
+```
+
+Response:
+Status: 401 Unauthorized
+```
+{
+  "error": "Not authenticated"
+}
+```
+
 User with no companies:
 ```
 {

--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,10 @@ Successful Response:
    - [Github](https://github.com/ccirbo)
    - [LinkedIn](https://www.linkedin.com/in/candicecirbo/)
 
+**Cochran, James**
+- [Github](https://github.com/James-Cochran)
+- [LinkedIn](https://www.linkedin.com/in/james-cochran-/)
+
 **Croy, Lito**
 - [Github](https://github.com/litobot)
 - [LinkedIn](https://www.linkedin.com/in/litocroy/)
@@ -1229,10 +1233,6 @@ Successful Response:
 **O'Leary, Ryan**
 - [Github](https://github.com/ROlearyPro)
 - [LinkedIn](https://www.linkedin.com/in/ryan-o-leary-6a963b211/)
-
-**Cochran, James**
-- [Github](https://github.com/James-Cochran)
-- [LinkedIn](https://www.linkedin.com/in/james-cochran-/)
 
 **Pintozzi, Erin - (Project Manager)**
 - [Github](https://github.com/epintozzi)

--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,10 @@ Successful Response:
 - [Github](https://github.com/ROlearyPro)
 - [LinkedIn](https://www.linkedin.com/in/ryan-o-leary-6a963b211/)
 
+**Cochran, James**
+- [Github](https://github.com/James-Cochran)
+- [LinkedIn](https://www.linkedin.com/in/james-cochran-/)
+
 **Pintozzi, Erin - (Project Manager)**
 - [Github](https://github.com/epintozzi)
 - [LinkedIn](https://www.linkedin.com/in/erin-pintozzi/)

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -24,14 +24,15 @@ module Api
       end
 
       def destroy
+        # binding.pry
         company = @current_user.companies.find_by(id: params[:id])
-
-        if company
+        if company.nil?
+          skip_authorization
+          return render json: { error: "Company not found" }, status: :not_found
+        end
+          authorize company 
           company.handle_deletion
           render json: { message: "Company successfully deleted" }, status: :no_content
-        else
-          render json: { error: "Company not found" }, status: :not_found
-        end
       end
 
       private

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -24,7 +24,6 @@ module Api
       end
 
       def destroy
-        # binding.pry
         company = @current_user.companies.find_by(id: params[:id])
         if company.nil?
           skip_authorization

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -31,7 +31,7 @@ module Api
         end
           authorize company 
           company.handle_deletion
-          render json: { message: "Company successfully deleted" }, status: :no_content
+          render json: { message: "Company successfully deleted" }, status: :ok
       end
 
       private

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -23,6 +23,17 @@ module Api
         end
       end
 
+      def destroy
+        company = @current_user.companies.find_by(id: params[:id])
+
+        if company
+          company.handle_deletion
+          render json: { message: "Company successfully deleted" }, status: :no_content
+        else
+          render json: { error: "Company not found" }, status: :not_found
+        end
+      end
+
       private
 
       def company_params

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,4 @@
 class Company < ApplicationRecord
-  # rolify strict: true
   belongs_to :user 
   has_many :contacts
   has_many :job_applications, dependent: :destroy

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,5 @@
 class Company < ApplicationRecord
-  rolify strict: true
+  # rolify strict: true
   belongs_to :user 
   has_many :contacts
   has_many :job_applications, dependent: :destroy

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,7 +2,12 @@ class Company < ApplicationRecord
   rolify strict: true
   belongs_to :user 
   has_many :contacts
-  has_many :job_applications
+  has_many :job_applications, dependent: :destroy
   
   validates :name, presence: true
+
+  def handle_deletion
+    contacts.update_all(company_id: nil)
+    destroy
+  end
 end

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -12,6 +12,11 @@ class CompanyPolicy < ApplicationPolicy
     user.present?
   end
 
+  def destroy?
+    return false unless user
+    admin? || record.user_id == user.id
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       return scope.none unless user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       resources :users, only: [:create, :index, :show, :update] do
 
         resources :job_applications, only: [:create, :index, :show, :update]
-        resources :companies, only: [:create, :index] do
+        resources :companies, only: [:create, :index, :destroy] do
           resources :contacts, only: [:create, :index]
         end
         resources :contacts, only: [:index, :create, :show]

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -4,10 +4,67 @@ RSpec.describe Company, type: :model do
   describe "associations" do
     it { should belong_to(:user) }
     it { should have_many(:contacts) }
-    it { should have_many(:job_applications) }
+    it { should have_many(:job_applications).dependent(:destroy) }
   end
 
   describe "validations" do
     it { should validate_presence_of(:name) }
+  end
+
+  describe "#handle_deletion" do
+    before(:each) do
+      @user = User.create!(name: "Yolonda Aberdeer", email: "yolodeer@aol.com", password: "nuggetbisket")
+
+      @company = Company.create!(
+        user: @user,
+        name: "Google",
+        website: "google.com",
+        street_address: "1600 Amphitheatre Parkway",
+        city: "Mountain View",
+        state: "CA",
+        zip_code: "94043",
+        notes: "Search engine"
+      )
+
+      @contact1 = Contact.create!(first_name: "John", last_name: "Doe", user: @user, company: @company)
+      @contact2 = Contact.create!(first_name: "Jane", last_name: "Smith", user: @user, company: @company)
+      
+      @job_application = JobApplication.create!(
+        position_title: "Jr. CTO",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Fingers crossed!",
+        job_description: "Looking for Turing grad/jr dev to be CTO",
+        application_url: "www.example.com",
+        company: @company,
+        user: @user
+      )
+    end
+
+    it "removes the company_id from associated contacts but does not delete them" do
+      expect(@contact1.company_id).to eq(@company.id)
+      expect(@contact2.company_id).to eq(@company.id)
+
+      @company.handle_deletion
+
+      expect(@contact1.reload.company_id).to be_nil
+      expect(@contact2.reload.company_id).to be_nil
+    end
+
+    it "deletes associated job applications" do
+      expect(JobApplication.find_by(id: @job_application.id)).not_to be_nil
+
+      @company.handle_deletion
+
+      expect(JobApplication.find_by(id: @job_application.id)).to be_nil
+    end
+
+    it "deletes the company" do
+      expect(Company.find_by(id: @company.id)).not_to be_nil
+
+      @company.handle_deletion
+
+      expect(Company.find_by(id: @company.id)).to be_nil
+    end
   end
 end

--- a/spec/policies/company_policy_spec.rb
+++ b/spec/policies/company_policy_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe CompanyPolicy, type: :policy do
     end
   end
 
+  permissions :destroy? do
+    it "allows an admin to delete any company" do
+      expect(subject).to permit(admin, company)
+      expect(subject).to permit(admin, other_company)
+    end
+
+    it "allows the user who created the company to delete it" do
+      expect(subject).to permit(user, company)
+    end
+
+    it "does not allow a user to delete another user's company" do
+      expect(subject).not_to permit(user, other_company)
+    end
+
+    it "does not allow guests to delete a company" do
+      expect(subject).not_to permit(nil, company)
+      expect(subject).not_to permit(nil, other_company)
+    end
+  end
+
   permissions ".scope" do
     let(:scope) { Pundit.policy_scope!(current_user, Company) }
 

--- a/spec/requests/api/v1/companies/delete_spec.rb
+++ b/spec/requests/api/v1/companies/delete_spec.rb
@@ -28,7 +28,7 @@ describe "Companies API", type: :request do
 
       delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer #{@token}", "Content-Type" => "application/json" }, as: :json
 
-      expect(response).to have_http_status(:no_content)
+      expect(response).to have_http_status(:ok)
       expect(Company.find_by(id: @google.id)).to be_nil
       expect(JobApplication.find_by(id: @job_application.id)).to be_nil
     end

--- a/spec/requests/api/v1/companies/delete_spec.rb
+++ b/spec/requests/api/v1/companies/delete_spec.rb
@@ -39,7 +39,7 @@ describe "Companies API", type: :request do
       expect(response).to have_http_status(:not_found)
       json = JSON.parse(response.body, symbolize_names: true)
 
-      expect(json[:error]).to eq("Not Found")
+      expect(json[:error]).to eq("Company not found")
     end
 
     it "returns an unauthorized error if no token is provided" do

--- a/spec/requests/api/v1/companies/delete_spec.rb
+++ b/spec/requests/api/v1/companies/delete_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe "Companies API", type: :request do
+  describe "Delete#action" do
+    before(:each) do
+      @user = User.create!(name: "Tom", email: "myspace_creator@email.com", password: "test123")
+
+      post api_v1_sessions_path, params: { email: @user.email, password: "test123" }, as: :json
+      @token = JSON.parse(response.body)["token"]
+
+      @google = Company.create!(user_id: @user.id, name: "Google", website: "google.com", street_address: "1600 Amphitheatre Parkway", city: "Mountain View", state: "CA", zip_code: "94043", notes: "Search engine")
+
+      @job_application = JobApplication.create!(
+        position_title: "Software Engineer",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Excited about this opportunity",
+        job_description: "Develop cutting-edge software solutions",
+        application_url: "www.example.com/job",
+        company_id: @google.id,
+        user_id: @user.id
+      )
+    end
+
+    it "successfully deletes a company and its associated job applications" do
+      expect(Company.find_by(id: @google.id)).not_to be_nil
+      expect(JobApplication.find_by(id: @job_application.id)).not_to be_nil
+
+      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer #{@token}" }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(Company.find_by(id: @google.id)).to be_nil
+      expect(JobApplication.find_by(id: @job_application.id)).to be_nil
+    end
+
+    it "returns an error if the company does not exist" do
+      delete "/api/v1/users/#{@user.id}/companies/9999", headers: { "Authorization" => "Bearer #{@token}" }, as: :json
+
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:error]).to eq("Not Found")
+    end
+
+    it "returns an unauthorized error if no token is provided" do
+      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:error]).to eq("Not authenticated")
+    end
+
+    it "returns an unauthorized error if an invalid token is provided" do
+      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer invalid.token.here" }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(json[:error]).to eq("Not authenticated")
+    end
+  end
+end

--- a/spec/requests/api/v1/companies/delete_spec.rb
+++ b/spec/requests/api/v1/companies/delete_spec.rb
@@ -26,7 +26,7 @@ describe "Companies API", type: :request do
       expect(Company.find_by(id: @google.id)).not_to be_nil
       expect(JobApplication.find_by(id: @job_application.id)).not_to be_nil
 
-      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer #{@token}" }, as: :json
+      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer #{@token}", "Content-Type" => "application/json" }, as: :json
 
       expect(response).to have_http_status(:no_content)
       expect(Company.find_by(id: @google.id)).to be_nil
@@ -34,7 +34,7 @@ describe "Companies API", type: :request do
     end
 
     it "returns an error if the company does not exist" do
-      delete "/api/v1/users/#{@user.id}/companies/9999", headers: { "Authorization" => "Bearer #{@token}" }, as: :json
+      delete "/api/v1/users/#{@user.id}/companies/9999", headers: { "Authorization" => "Bearer #{@token}", "Content-Type" => "application/json" }, as: :json
 
       expect(response).to have_http_status(:not_found)
       json = JSON.parse(response.body, symbolize_names: true)
@@ -52,7 +52,7 @@ describe "Companies API", type: :request do
     end
 
     it "returns an unauthorized error if an invalid token is provided" do
-      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer invalid.token.here" }, as: :json
+      delete "/api/v1/users/#{@user.id}/companies/#{@google.id}", headers: { "Authorization" => "Bearer invalid.token.here", "Content-Type" => "application/json" }, as: :json
 
       expect(response).to have_http_status(:unauthorized)
       json = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
## Type of Change
- [ X ] feature ⛲
- [ X ] documentation update 📃
- [ X ] testing 🧪
<!--- Delete any above that do not apply to this PR -->

## Description
This PR adds the ability to delete a company for a user through the DELETE /api/v1/users/:userid/companies/:id endpoint.

When a company is deleted, any associated job applications are also removed, while contacts remain intact.

I commented out strict: true in the CompaniesController Rolify call. Wally  and I believe this was mistakenly included. After reviewing the Rolify documentation, we found no reason for its presence in this controller. All tests still pass with it commented out.

Documentation in the README was updated for this endpoint.

Tests were written for successful and unsuccessful requests (unauthorized access, non-existent company).

## Motivation and Context
This change was required to allow users to remove companies they no longer need while maintaining data integrity by keeping contacts but removing job applications.

## Related Tickets
closes #70 https://github.com/turingschool/tracker-crm/issues/70

## Added Test?
- [ X ] Yes 🫡
  - Request / Controller Tests
  - Model Tests
  - Policy Tests
- [ ] No 🙅
- [ X ] All previous tests still pass 🥳

## Checklist:
- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ ] This PR includes a Migration and I have notified the deployment team and PM so they can run the migration after the PR is merged.