### PR TITLE
Fix/Company Model: Notes was set to allow NIL, but data is coming in …

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -10,7 +10,7 @@ class Company < ApplicationRecord
   validates :city, presence: true, allow_blank: false
   validates :state, presence: true, allow_blank: false
   validates :zip_code, presence: true, allow_blank: false
-  validates :notes, presence: true, allow_nil: true
+  validates :notes, presence: true, allow_blank: true
 
   def self.find_company(user, company_id)
     if company = user.companies.find_by(id: company_id)


### PR DESCRIPTION
…as blank, changed to allow blank

## Type of Change

- [x] bug fix 🐛

<!--- Delete any above that do not apply to this PR -->

## Description
<!--- Describe your changes in detail -->
Company Model: notes validation was set to allow NIL, post from FE has notes as blank when no content, changed validator to allow blank

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/turingschool/tracker-crm/issues/120
Users were unable to save companies w/o notes being present

## Related Tickets
<!--- example: closes #12 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
https://github.com/turingschool/tracker-crm/issues/120

## Screenshots (if appropriate):

## Added Test?
- [ ] Yes 🫡
  - <!--- If yes, what type? Integration(FE), Unit/Model or Request/Controller Specs?-->
- [x] No 🙅
- [x] All previous tests still pass 🥳
<!--- Delete any above that do not apply to this PR -->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR includes a Migration and I have notified the deployment team and PM so they can run the migration after the PR is merged.