### PR TITLE
Feat/be/user dashboard conditional logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1390,6 +1390,10 @@ Successful Response:
 - [Github](https://github.com/epintozzi)
 - [LinkedIn](https://www.linkedin.com/in/erin-pintozzi/)
 
+**Riley, Alora**
+- [Github](https://github.com/aloraalee)
+- [LinkedIn](https://www.linkedin.com/in/alorariley/)
+
 **Salazar, Kaelin**
 - [Github](https://github.com/kaelinpsalazar)
 - [LinkedIn](https://www.linkedin.com/in/kaelin-salazar/)

--- a/app/controllers/api/v1/dashboards_controller.rb
+++ b/app/controllers/api/v1/dashboards_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::DashboardsController < ApplicationController
   def show
     user = current_user
     authorize user
-    render json: DashboardSerializer.new(user), status: :ok
+    weekly_summary = Dashboard.filter_weekly_summary(user)
+    render json: DashboardSerializer.new(user, params: {weekly_summary: weekly_summary}), status: :ok
   end
 end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -1,9 +1,9 @@
 class Dashboard < ApplicationRecord
   def self.filter_weekly_summary(user)
     {
-      job_applications: user.job_applications.where('created_at >= ?', 7.days.ago),
-      contacts: user.contacts.where('created_at >= ?', 7.days.ago),
-      companies: user.companies.where('created_at >= ?', 7.days.ago)
+      job_applications: user.job_applications.where('created_at > ?', 7.days.ago),
+      contacts: user.contacts.where('created_at > ?', 7.days.ago),
+      companies: user.companies.where('created_at > ?', 7.days.ago)
     }
   end
 end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -1,0 +1,9 @@
+class Dashboard < ApplicationRecord
+  def self.filter_weekly_summary(user)
+    {
+      job_applications: user.job_applications.where('created_at >= ?', 7.days.ago),
+      contacts: user.contacts.where('created_at >= ?', 7.days.ago),
+      companies: user.companies.where('created_at >= ?', 7.days.ago)
+    }
+  end
+end

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -2,13 +2,9 @@ class DashboardSerializer
   include JSONAPI::Serializer
   attributes :id, :name, :email
 
-  attribute :dashboard do |user|
+  attribute :dashboard do |user, params|
     {
-      weekly_summary: {
-        job_applications: user.job_applications.where('created_at >= ?', 7.days.ago),
-        contacts: user.contacts.where('created_at >= ?', 7.days.ago),
-        companies: user.companies.where('created_at >= ?', 7.days.ago)
-      }
+      weekly_summary: params[:weekly_summary]
     }
   end
 end

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -5,9 +5,9 @@ class DashboardSerializer
   attribute :dashboard do |user|
     {
       weekly_summary: {
-        job_applications: user.job_applications,
-        contacts: user.contacts,
-        companies: user.companies
+        job_applications: user.job_applications.where('created_at >= ?', 7.days.ago),
+        contacts: user.contacts.where('created_at >= ?', 7.days.ago),
+        companies: user.companies.where('created_at >= ?', 7.days.ago)
       }
     }
   end

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -24,12 +24,144 @@ RSpec.describe Dashboard, type: :model do
         user_id: user.id,
         created_at: 2.days.ago)
       contact = Contact.create!(first_name: "John", last_name: "Smith", user_id: user.id, company: company, created_at: 3.days.ago)
-
+      job_application = JobApplication.create!(
+        position_title: "Jr. CTO",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Fingers crossed!",
+        job_description: "Looking for Turing grad/jr dev to be CTO",
+        application_url: "www.example.com",
+        company_id: company.id,
+        user_id: user.id,
+        created_at: 8.days.ago
+      )
       expect(Dashboard.filter_weekly_summary(user)).to eq({
         job_applications: [],
         contacts: [contact],
         companies: [company_2]
       })
     end
+
+    it "returns an empty array if no new data in the past week" do
+      user = User.create!(name: "Danny DeVito", email: "danny_de@email.com", password: "jerseyMikesRox7")
+      company = Company.create!(
+        user_id: user.id,
+        name: "Google",
+        website: "google.com",
+        street_address: "1600 Amphitheatre Parkway",
+        city: "Mountain View",
+        state: "CA",
+        zip_code: "94043",
+        notes: "Search engine",
+        created_at: 9.days.ago)
+      company_2 = Company.create!(
+        name: "Turing", 
+        website: "www.turing.com", 
+        street_address: "123 Main St",
+        city: "Denver",
+        state: "CO",
+        zip_code: "80218",
+        user_id: user.id,
+        created_at: 10.days.ago)
+      contact = Contact.create!(first_name: "John", last_name: "Smith", user_id: user.id, company: company, created_at: 9.days.ago)
+      job_application = JobApplication.create!(
+        position_title: "Jr. CTO",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Fingers crossed!",
+        job_description: "Looking for Turing grad/jr dev to be CTO",
+        application_url: "www.example.com",
+        company_id: company.id,
+        user_id: user.id,
+        created_at: 8.days.ago
+      )
+      expect(Dashboard.filter_weekly_summary(user)).to eq({
+        job_applications: [],
+        contacts: [],
+        companies: []
+      })
+    end
+
+    it "returns an empty array if the data is exactly 7 days old" do
+      user = User.create!(name: "Danny DeVito", email: "danny_de@email.com", password: "jerseyMikesRox7")
+      company = Company.create!(
+        user_id: user.id,
+        name: "Google",
+        website: "google.com",
+        street_address: "1600 Amphitheatre Parkway",
+        city: "Mountain View",
+        state: "CA",
+        zip_code: "94043",
+        notes: "Search engine",
+        created_at: 7.days.ago)
+      company_2 = Company.create!(
+        name: "Turing", 
+        website: "www.turing.com", 
+        street_address: "123 Main St",
+        city: "Denver",
+        state: "CO",
+        zip_code: "80218",
+        user_id: user.id,
+        created_at: 6.days.ago.end_of_day)
+      contact = Contact.create!(first_name: "John", last_name: "Smith", user_id: user.id, company: company, created_at: 7.days.ago)
+      job_application = JobApplication.create!(
+        position_title: "Jr. CTO",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Fingers crossed!",
+        job_description: "Looking for Turing grad/jr dev to be CTO",
+        application_url: "www.example.com",
+        company_id: company.id,
+        user_id: user.id,
+        created_at: 7.days.ago
+      )
+      expect(Dashboard.filter_weekly_summary(user)).to eq({
+        job_applications: [],
+        contacts: [],
+        companies: [company_2]
+      })
+    end
+
+    it "returns data for only the given user" do
+      user = User.create!(name: "Danny DeVito", email: "danny_de@email.com", password: "jerseyMikesRox7")
+      user_2 = User.create!(name: "Yolonda Aberdeer", email: "yolodeer@aol.com", password: "nuggetbisket"
+      )
+      company = Company.create!(
+        user_id: user_2.id,
+        name: "Google",
+        website: "google.com",
+        street_address: "1600 Amphitheatre Parkway",
+        city: "Mountain View",
+        state: "CA",
+        zip_code: "94043",
+        notes: "Search engine",
+        created_at: 3.days.ago)
+      company_2 = Company.create!(
+        name: "Turing", 
+        website: "www.turing.com", 
+        street_address: "123 Main St",
+        city: "Denver",
+        state: "CO",
+        zip_code: "80218",
+        user_id: user.id,
+        created_at: 3.days.ago)
+      contact = Contact.create!(first_name: "John", last_name: "Smith", user_id: user_2.id, company: company, created_at: 3.days.ago)
+      job_application = JobApplication.create!(
+        position_title: "Jr. CTO",
+        date_applied: "2024-10-31",
+        status: 1,
+        notes: "Fingers crossed!",
+        job_description: "Looking for Turing grad/jr dev to be CTO",
+        application_url: "www.example.com",
+        company_id: company.id,
+        user_id: user_2.id,
+        created_at: 14.days.ago
+      )
+      expect(Dashboard.filter_weekly_summary(user_2)).to eq({
+        job_applications: [],
+        contacts: [contact],
+        companies: [company]
+      })
+    end    
   end
 end

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Dashboard, type: :model do
+  describe "dashboard data" do
+    it "can filter data to only return if it was created less than a week ago" do
+      user = User.create!(name: "Danny DeVito", email: "danny_de@email.com", password: "jerseyMikesRox7")
+      company = Company.create!(
+        user_id: user.id,
+        name: "Google",
+        website: "google.com",
+        street_address: "1600 Amphitheatre Parkway",
+        city: "Mountain View",
+        state: "CA",
+        zip_code: "94043",
+        notes: "Search engine",
+        created_at: 9.days.ago)
+      company_2 = Company.create!(
+        name: "Turing", 
+        website: "www.turing.com", 
+        street_address: "123 Main St",
+        city: "Denver",
+        state: "CO",
+        zip_code: "80218",
+        user_id: user.id,
+        created_at: 2.days.ago)
+      contact = Contact.create!(first_name: "John", last_name: "Smith", user_id: user.id, company: company, created_at: 3.days.ago)
+
+      expect(Dashboard.filter_weekly_summary(user)).to eq({
+        job_applications: [],
+        contacts: [contact],
+        companies: [company_2]
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Type of Change
- [x] feature ⛲
- [x] testing 🧪

## Description
This PR adds logic to the dashboard to only render job applications, contacts, and companies to the dashboard if they were created in the last seven days. This is done with a method in the dashboard model, and it is tested as well. 

## Motivation and Context
Filtering the data on the backend with Active Record helps to maintain efficiency by only sending data from the last seven days to the dashboard. The reason for the seven-day limit is to incentivize the user to add new job applications, contacts or companies if they have not already done so. 

## Added Test?
- [x] Yes 🫡
 Model Specs
- [x] All previous tests still pass 🥳

## Checklist:
- [x] My code follows the code style of this project.