### PR TITLE
Fix/allow multiple same name contacts

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -9,12 +9,7 @@ class Contact < ApplicationRecord
 
   validates :first_name, presence: {message: "can't be blank"} 
   validates :last_name, presence: {message: "can't be blank"}
-  
-  validates :first_name, uniqueness: { 
-    scope: [:last_name, :user_id], 
-    case_sensitive: false,
-    message: "and Last name already exist for this user"
-}
+
   validates :phone_number, format: { with: VALID_PHONE_REGEX, message: "must be in the format '555-555-5555'" }, allow_blank: true
   validates :email, format: { with: VALID_EMAIL_REGEX, message: "must be a valid email address" }, allow_blank: true
 

--- a/db/migrate/20250403224322_remove_unique_constraint_from_contacts_name.rb
+++ b/db/migrate/20250403224322_remove_unique_constraint_from_contacts_name.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueConstraintFromContactsName < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :contacts, name: "index_contacts_on_user_id_and_full_name"
+    add_index :contacts, [:user_id, :first_name, :last_name], name: "index_contacts_on_user_id_and_full_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_26_230710) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_03_224322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_26_230710) do
     t.bigint "user_id", null: false
     t.bigint "company_id"
     t.index ["company_id"], name: "index_contacts_on_company_id"
-    t.index ["user_id", "first_name", "last_name"], name: "index_contacts_on_user_id_and_full_name", unique: true
+    t.index ["user_id", "first_name", "last_name"], name: "index_contacts_on_user_id_and_full_name"
     t.index ["user_id"], name: "index_contacts_on_user_id"
   end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Contact, type: :model do
         expect(same_contact).to be_valid
       end
 
+      it "allows duplicate names for same user" do
+        contact = Contact.create!(first_name: "Jack", last_name: "Frost", user: @user1)
+        duplicate_contact = Contact.new(first_name: "Jack", last_name: "Frost", user: @user1)
+
+        expect(duplicate_contact).to be_valid
+      end
+
       it "capitalizes names before saving" do
         contact = Contact.create!(first_name: " sandy ", last_name: "johnson", user: @user1)
         expect(contact.first_name).to eq("Sandy")

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -16,21 +16,6 @@ RSpec.describe Contact, type: :model do
         @user2 = User.create!(name: "Mary", email: "jolly@gmail.com", password: "Password")
       end
 
-      it "is valid with a unique first_name and last_name for the same user" do
-        Contact.create!(first_name: "John", last_name: "Smith", user: @user1)
-        unique_contact = Contact.new(first_name: "Jane", last_name: "Smith", user: @user1)
-
-        expect(unique_contact).to be_valid
-      end
-
-      it "is not valid without a unique first_name and last_name for the same user" do
-        Contact.create!(first_name: "John", last_name: "Smith", user: @user1)
-        duplicate_contact = Contact.new(first_name: "John", last_name: "Smith", user: @user1)
-
-        expect(duplicate_contact).not_to be_valid
-        expect(duplicate_contact.errors[:first_name]).to include("and Last name already exist for this user")
-      end
-
       it "allows duplicate names for different users" do
         contact = Contact.create!(first_name: "John", last_name: "Smith", user: @user1)
         same_contact = Contact.new(first_name: "John", last_name: "Smith", user: @user2)
@@ -42,14 +27,6 @@ RSpec.describe Contact, type: :model do
         contact = Contact.create!(first_name: " sandy ", last_name: "johnson", user: @user1)
         expect(contact.first_name).to eq("Sandy")
         expect(contact.last_name).to eq("Johnson")
-      end
-
-      it "does not allow duplicates with case or whitespace differences" do
-        Contact.create!(first_name: "Sandy", last_name: "Johnson", user: @user1)
-        duplicate_contact = Contact.new(first_name: "sandy", last_name: " johnson ", user: @user1)
-
-        expect(duplicate_contact).not_to be_valid
-        expect(duplicate_contact.errors.full_messages).to include("First name and Last name already exist for this user")
       end
 
       it "is valid with a company" do

--- a/spec/requests/api/v1/contacts/create_spec.rb
+++ b/spec/requests/api/v1/contacts/create_spec.rb
@@ -112,23 +112,6 @@ describe "Contacts Controller", type: :request do
 				user_id: @user1.id)
 		end
 
-		it "returns a 422 error when creating a duplicate contact" do
-      minimal_params =  { contact: {first_name: "John", last_name: "Smith" } }
-      post api_v1_user_contacts_path(@user1.id), params: minimal_params , headers: { "Authorization" => "Bearer #{@token}" }, as: :json
-
-      expect(response).to have_http_status(:created)
-			expect(response).to be_successful
-
-      post api_v1_user_contacts_path(@user1.id), params: minimal_params , headers: { "Authorization" => "Bearer #{@token}" }, as: :json
-			expect(response).to_not be_successful
-			expect(response).to have_http_status(:unprocessable_entity)
-
-      json = JSON.parse(response.body, symbolize_names: true)
-
-			expect(json[:message]).to include("First name and Last name already exist for this user")
-			expect(json[:status]).to eq(422)
-	end
-
 		it "returns a 422 error for missing first_name" do
 			missing_contact_params = { contact: { first_name: "", last_name: "Smith" } }
 

--- a/spec/requests/api/v1/dashboard/dashboards_spec.rb
+++ b/spec/requests/api/v1/dashboard/dashboards_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "DashboardsController", type: :request do
         headers: { "Authorization" => "Bearer #{@token}" }, as: :json
       post "/api/v1/users/#{user.id}/job_applications", params: { job_application: job_application2_params },
         headers: { "Authorization" => "Bearer #{@token}" }, as: :json
-      post "/api/v1/users/#{user.id}/contacts", params: contact_params,
+      post "/api/v1/users/#{user.id}/contacts", params: { contact_params: contact_params },
         headers: { "Authorization" => "Bearer #{@token}" }, as: :json
       end
 


### PR DESCRIPTION
### Type of Change
- [x] bug fix 🐛
- [x] refactor 🧑‍💻
- [x] testing 🧪

### Description
Removed the uniqueness validation for first and last name in the Contact model to allow multiple contacts with the same name. This change involved creating a new migration to update the schema and remove the uniqueness constraint on these fields. Corresponding tests for uniqueness validation were deleted, and a new test was added to ensure that a user can have multiple contacts with the same first and last name.

### Share the reason(s) for this pull request
To allow a user the option to add multiple contacts with the same name. 

### What questions do you have/what do you want feedback on?
Double check what I removed wont be needed in the future and should be commented out instead. 

### Related Tickets
This will close issue #154 

### Screenshots (if applicable):
<img width="1417" alt="Screenshot 2025-04-03 at 5 14 00 PM" src="https://github.com/user-attachments/assets/7da863de-84af-4b87-bbf6-7237510235d0" />

### Added Test?
- [x] Yes 🫡
  Unit/Model Test

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All tests (previous and new) pass 🥳
- [x] This PR includes a Migration and I have notified the PM so they can run the migration after the PR is merged.

### How to QA this change:
On front end check that it allows you to add contacts with the same name and on the backend run the models test file to verify all existing and new tests are passing. 


